### PR TITLE
Bump for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-store-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Customizable utility functions to generate vuex stores, facilitating network requests.",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
1.0.2 isn't installable, so bumping to 1.0.3