### PR TITLE
Provide params to mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ export const cats = {
     errors: state => state.erroredGet.errors
   },
   mutations: {
-    requestedGet(state) {
+    requestedGet(state, params) {
       state.loadedGet = false;
       state.erroredGet = {};
     },
-    receivedGet(state, data) {
-      data.forEach(datum => Vue.set(state.byId, datum.id, datum));
+    receivedGet(state, { response, params }) {
+      params.forEach(datum => Vue.set(state.byId, datum.id, datum));
       state.loadedGet = true;
     },
     failedGet(state, errors) {
@@ -143,14 +143,14 @@ export const cats = {
   actions: {
     async get({ commit }, params) {
       let response;
-      commit("requestedGet");
+      commit("requestedGet", params);
       try {
         response = await getListOfCats(params);
       } catch (error) {
         commit("failedGet", error);
         return error;
       }
-      commit("receivedGet", response);
+      commit("receivedGet", { response, params });
       return response;
     }
   }
@@ -183,8 +183,8 @@ export default vuexStoreBuilder("get", getListOfDogs, {
       state.ownerIdToDogIds = {};
     }
   },
-  receive(state, dogs) {
-    dogs.forEach(dog => {
+  receive(state, { response, params }) {
+    response.forEach(dog => {
       const dogId = getDogId(dog);
       state.byId[dogId] = dog;
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ export const cats = {
       state.erroredGet = {};
     },
     receivedGet(state, { response, params }) {
-      params.forEach(datum => Vue.set(state.byId, datum.id, datum));
+      response.forEach(datum => Vue.set(state.byId, datum.id, datum));
       state.loadedGet = true;
     },
     failedGet(state, errors) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-store-builder",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Customizable utility functions to generate vuex stores, facilitating network requests.",
   "main": "build/index.js",
   "scripts": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -13,13 +13,13 @@ export const defaultActionBuilder = (
   } = {}
 ) => async ({ commit }, params) => {
   let response;
-  commit(requestedMutationName);
+  commit(requestedMutationName, params);
   try {
     response = await call(params);
   } catch (error) {
     return catchBlock.call({ commit }, error);
   }
-  commit(receivedMutationName, response);
+  commit(receivedMutationName, { response, params });
   return response;
 };
 

--- a/src/actions.spec.js
+++ b/src/actions.spec.js
@@ -23,14 +23,15 @@ describe("actions", () => {
     const requestedMutationName = "requestedMutationName";
     const receivedMutationName = "receivedMutationName";
     const failedMutationName = "failedMutationName";
+    const params = {};
     const response = { response: "response" };
     const error = { error: "error" };
     it.each([
-      [requestedMutationName, () => {}, [requestedMutationName]],
+      [requestedMutationName, () => {}, [requestedMutationName, params]],
       [
         receivedMutationName,
         () => Promise.resolve(response),
-        [receivedMutationName, response],
+        [receivedMutationName, { response, params }],
         1
       ],
       [
@@ -42,14 +43,18 @@ describe("actions", () => {
     ])("%s", async (mutationName, call, args, index = 0) => {
       await defaultActionBuilder(slug, call, {
         [mutationName]: mutationName
-      })({ commit }, {});
+      })({ commit }, params);
       expect(commit.mock.calls[index]).toEqual(args);
     });
   });
-  it("calls action with correct parameters", () => {
+  it("calls action with correct parameters", async () => {
+    const response = {};
     const call = jest.fn();
     const parameters = {};
-    defaultActionBuilder(slug, call)({ commit: () => {} }, parameters);
+    call.mockResolvedValueOnce(response);
+    expect(
+      await defaultActionBuilder(slug, call)({ commit: () => {} }, parameters)
+    ).toBe(response);
     expect(call.mock.calls[0][0]).toBe(parameters);
   });
 });

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -1,17 +1,17 @@
 import { loaded, errored } from "./strings";
 
 export const requestBuilder = slug =>
-  function(state) {
+  function(state, params) {
     state[loaded(slug)] = false;
     state[errored(slug)] = {};
   };
 
 export const receiveBuilder = (slug, getKey) =>
-  function(state, data) {
-    if (Array.isArray(data)) {
-      data.forEach(datum => (state.byId[getKey(datum)] = datum));
+  function(state, { response, params } = {}) {
+    if (Array.isArray(response)) {
+      response.forEach(datum => (state.byId[getKey(datum)] = datum));
     } else {
-      state.byId[getKey(data)] = data;
+      state.byId[getKey(response)] = response;
     }
     state[loaded(slug)] = true;
   };

--- a/src/mutations.spec.js
+++ b/src/mutations.spec.js
@@ -17,14 +17,14 @@ describe("mutation builders", () => {
     });
   });
   describe("receiveBuilder", () => {
-    const getKey = jest.fn(({ id }) => id);
+    const getKey = jest.fn(({ id } = {}) => id);
     it("handles data arrays", () => {
       const datum1 = { id: 123 };
       const datum2 = { id: 234 };
       const state = {
         byId: {}
       };
-      receiveBuilder(slug, getKey)(state, [datum1, datum2]);
+      receiveBuilder(slug, getKey)(state, { response: [datum1, datum2] });
       expect(state.byId).toEqual({
         123: datum1,
         234: datum2
@@ -35,7 +35,7 @@ describe("mutation builders", () => {
       const state = {
         byId: {}
       };
-      receiveBuilder(slug, getKey)(state, datum);
+      receiveBuilder(slug, getKey)(state, { response: datum });
       expect(state.byId).toEqual({
         123: datum
       });


### PR DESCRIPTION
This PR reworks the action template to provide `{ response, params }` to the receive mutation, and `params` to the request mutation.

This opens the door for more specific, custom behavior for mutations.